### PR TITLE
Return empty array on get all tx by alias

### DIFF
--- a/handler/multisig_handler.go
+++ b/handler/multisig_handler.go
@@ -94,14 +94,6 @@ func (h *MultisigHandler) GetAllMultisigTxForAlias(ctx *gin.Context) {
 			})
 		return
 	}
-	if multisigTx == nil {
-		ctx.JSON(400,
-			&dto.SignavaultError{
-				Message: fmt.Sprintf("Multisig transactions not found for alias %s", alias),
-				Error:   "not found",
-			})
-		return
-	}
 	ctx.JSON(200, multisigTx)
 }
 

--- a/service/multisig_service.go
+++ b/service/multisig_service.go
@@ -127,10 +127,8 @@ func (s *multisigService) GetAllMultisigTxForAlias(alias string, timestamp strin
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get txs for alias %s: %w", alias, err)
 	}
-	if tx == nil {
-		return nil, nil
-	}
-	if len(*tx) <= 0 {
+
+	if tx == nil || len(*tx) <= 0 {
 		return &[]model.MultisigTx{}, nil
 	}
 


### PR DESCRIPTION
## Description

This PR will return an empty array when the client passes an alias that does not exist in the database instead of an error response.