### PR TITLE
Fix for db timezone change affecting timestamp

### DIFF
--- a/dao/multisig_tx_dao.go
+++ b/dao/multisig_tx_dao.go
@@ -60,11 +60,11 @@ func (d *multisigTxDao) CreateMultisigTx(id string, alias string, threshold int,
 		return "", err
 	}
 
-	stmt, err := tx.Prepare("INSERT INTO multisig_tx (id, alias, threshold, unsigned_tx, output_owners, metadata) VALUES (?, ?, ?, ?, ?, ?)")
+	stmt, err := tx.Prepare("INSERT INTO multisig_tx (id, alias, threshold, unsigned_tx, output_owners, metadata, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)")
 	if err != nil {
 		return "", err
 	}
-	_, err = stmt.Exec(id, alias, threshold, unsignedTx, outputOwners, metadata)
+	_, err = stmt.Exec(id, alias, threshold, unsignedTx, outputOwners, metadata, time.Now().UTC())
 	if err != nil {
 		if rollbackErr := tx.Rollback(); rollbackErr != nil {
 			log.Printf("Execute statement failed: %v, unable to rollback: %v", err, rollbackErr)
@@ -81,11 +81,11 @@ func (d *multisigTxDao) CreateMultisigTx(id string, alias string, threshold int,
 			ownerSignature = signature
 		}
 
-		stmt, err := tx.Prepare("INSERT INTO multisig_tx_owners (multisig_tx_id, address, signature, is_signer) VALUES (?, ?, ?, ?)")
+		stmt, err := tx.Prepare("INSERT INTO multisig_tx_owners (multisig_tx_id, address, signature, is_signer, created_at) VALUES (?, ?, ?, ?, ?)")
 		if err != nil {
 			return "", err
 		}
-		_, err = stmt.Exec(id, owner, ownerSignature, isSigner)
+		_, err = stmt.Exec(id, owner, ownerSignature, isSigner, time.Now().UTC())
 		if err != nil {
 			if rollbackErr := tx.Rollback(); rollbackErr != nil {
 				log.Printf("Execute statement failed: %v, unable to rollback: %v", err, rollbackErr)
@@ -201,7 +201,7 @@ func (d *multisigTxDao) GetMultisigTx(id string, alias string, owner string) (*[
 				TransactionId: txTransactionId.String,
 				OutputOwners:  txOutputOwners,
 				Metadata:      txMetadata,
-				Timestamp:     txCreatedAt,
+				Timestamp:     txCreatedAt.UTC(),
 			}
 		}
 

--- a/db/migrations/001_multisig_schema.up.sql
+++ b/db/migrations/001_multisig_schema.up.sql
@@ -7,7 +7,7 @@ CREATE TABLE multisig_tx
     transaction_id  VARCHAR(56)     NULL,
     output_owners   VARCHAR(255)    NOT NULL,
     metadata        VARCHAR(255)    NOT NULL,
-    created_at      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at      DATETIME        NOT NULL,
     PRIMARY KEY (id)
 );
 
@@ -20,7 +20,7 @@ CREATE TABLE multisig_tx_owners
     address        CHAR(51)         NOT NULL,
     signature      VARCHAR(255)     NULL,
     is_signer      BOOLEAN          NOT NULL DEFAULT FALSE,
-    created_at     TIMESTAMP        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at     DATETIME         NOT NULL,
     FOREIGN KEY (multisig_tx_id) REFERENCES multisig_tx (id),
     PRIMARY KEY (multisig_tx_id, address)
 );

--- a/service/multisig_service_test.go
+++ b/service/multisig_service_test.go
@@ -8,6 +8,7 @@ package service
 import (
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/chain4travel/camino-signavault/dao"
 	"github.com/chain4travel/camino-signavault/dto"
@@ -32,7 +33,7 @@ func TestCreateMultisigTx(t *testing.T) {
 	}
 
 	unsignedTx := "000000002004000003ea010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-	id := "bc6246f58b5aba675f4071bd1a13d7a774384e42f301208d1c2b0f22ee602e69"
+	id := "cec9762115a58339c0f5e9ae582c1879300c1ff7303f9b566a95cf5ebe2a9d28"
 
 	alias := "P-kopernikus1k4przmfu79ypp4u7y98glmdpzwk0u3sc7saazy"
 	mockAliasInfo := &model.AliasInfo{
@@ -53,6 +54,7 @@ func TestCreateMultisigTx(t *testing.T) {
 		TransactionId: "",
 		OutputOwners:  "OutputOwners",
 		Metadata:      "",
+		Timestamp:     time.Now(),
 		Owners: []model.MultisigTxOwner{
 			{
 				MultisigTxId: id,

--- a/test/data/test_data.sql
+++ b/test/data/test_data.sql
@@ -1,11 +1,11 @@
-INSERT INTO multisig_tx (id, unsigned_tx, alias, threshold, metadata, output_owners) VALUES ('1', 'unsigned_tx', 'alias', 2, 'metadata', 'output_owners');
-INSERT INTO multisig_tx_owners (multisig_tx_id, address, signature, is_signer) VALUES ('1', 'address', 'signature', true);
+INSERT INTO multisig_tx (id, unsigned_tx, alias, threshold, metadata, output_owners, created_at) VALUES ('1', 'unsigned_tx', 'alias', 2, 'metadata', 'output_owners', NOW());
+INSERT INTO multisig_tx_owners (multisig_tx_id, address, signature, is_signer, created_at) VALUES ('1', 'address', 'signature', true, NOW());
 
-INSERT INTO multisig_tx (id, unsigned_tx, alias, threshold, metadata, output_owners, transaction_id) VALUES ('2', 'unsigned_tx_2', 'alias_2', 3, 'metadata_2', 'output_owners_2', 'transaction_id_2');
-INSERT INTO multisig_tx_owners (multisig_tx_id, address, signature, is_signer) VALUES ('2', 'address1', 'signature1', true);
-INSERT INTO multisig_tx_owners (multisig_tx_id, address, signature, is_signer) VALUES ('2', 'address2', 'signature2', true);
-INSERT INTO multisig_tx_owners (multisig_tx_id, address, signature, is_signer) VALUES ('2', 'address3', 'signature3', true);
+INSERT INTO multisig_tx (id, unsigned_tx, alias, threshold, metadata, output_owners, transaction_id, created_at) VALUES ('2', 'unsigned_tx_2', 'alias_2', 3, 'metadata_2', 'output_owners_2', 'transaction_id_2', NOW());
+INSERT INTO multisig_tx_owners (multisig_tx_id, address, signature, is_signer, created_at) VALUES ('2', 'address1', 'signature1', true, NOW());
+INSERT INTO multisig_tx_owners (multisig_tx_id, address, signature, is_signer, created_at) VALUES ('2', 'address2', 'signature2', true, NOW());
+INSERT INTO multisig_tx_owners (multisig_tx_id, address, signature, is_signer, created_at) VALUES ('2', 'address3', 'signature3', true, NOW());
 
-INSERT INTO multisig_tx (id, unsigned_tx, alias, threshold, metadata, output_owners) VALUES ('3', 'unsigned_tx_3', 'alias_3', 2, 'metadata_3','output_owners_3');
-INSERT INTO multisig_tx_owners (multisig_tx_id, address, signature, is_signer) VALUES ('3', 'address1', 'signature1', true);
-INSERT INTO multisig_tx_owners (multisig_tx_id, address, signature, is_signer) VALUES ('3', 'address2', 'signature2', true);
+INSERT INTO multisig_tx (id, unsigned_tx, alias, threshold, metadata, output_owners, created_at) VALUES ('3', 'unsigned_tx_3', 'alias_3', 2, 'metadata_3','output_owners_3', NOW());
+INSERT INTO multisig_tx_owners (multisig_tx_id, address, signature, is_signer, created_at) VALUES ('3', 'address1', 'signature1', true, NOW());
+INSERT INTO multisig_tx_owners (multisig_tx_id, address, signature, is_signer, created_at) VALUES ('3', 'address2', 'signature2', true, NOW());


### PR DESCRIPTION
## Description

This PR is altering the use of the created_at field on the multisix_tx table & multisig_tx_owners table by using the datetime mysql type instead of the timestamp type.

The reason is that using a timestamp the datetime is converted to UTC in the database but when is read back is dependent on the server's default timezone. Also, changing the server's timezone will affect the data that were inserted with a previous timezone.

Using a mysql datetime type we are keeping the timezone information of when the insertion occurred and is not dependent on the server's configured timezone. Any change in the timezone will not affect our already stored data. We can therefore convert to any timezone we want. In the background, the data are also stored as UTC in the database.