### PR TITLE
Added expiration date for transactions

### DIFF
--- a/dao/mock_multisig_tx_dao.go
+++ b/dao/mock_multisig_tx_dao.go
@@ -6,6 +6,7 @@ package dao
 
 import (
 	reflect "reflect"
+	time "time"
 
 	model "github.com/chain4travel/camino-signavault/model"
 	gomock "github.com/golang/mock/gomock"
@@ -50,18 +51,18 @@ func (mr *MockMultisigTxDaoMockRecorder) AddSigner(arg0, arg1, arg2 interface{})
 }
 
 // CreateMultisigTx mocks base method.
-func (m *MockMultisigTxDao) CreateMultisigTx(arg0, arg1 string, arg2 int, arg3, arg4, arg5, arg6, arg7 string, arg8 []string) (string, error) {
+func (m *MockMultisigTxDao) CreateMultisigTx(arg0, arg1 string, arg2 int, arg3, arg4, arg5, arg6, arg7 string, arg8 []string, arg9 *time.Time) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateMultisigTx", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+	ret := m.ctrl.Call(m, "CreateMultisigTx", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateMultisigTx indicates an expected call of CreateMultisigTx.
-func (mr *MockMultisigTxDaoMockRecorder) CreateMultisigTx(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 interface{}) *gomock.Call {
+func (mr *MockMultisigTxDaoMockRecorder) CreateMultisigTx(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMultisigTx", reflect.TypeOf((*MockMultisigTxDao)(nil).CreateMultisigTx), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMultisigTx", reflect.TypeOf((*MockMultisigTxDao)(nil).CreateMultisigTx), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
 }
 
 // GetMultisigTx mocks base method.

--- a/dao/multisig_tx_dao_test.go
+++ b/dao/multisig_tx_dao_test.go
@@ -113,6 +113,7 @@ func TestCreateMultisigTx(t *testing.T) {
 		outputOwners string
 		owners       []string
 		metadata     string
+		expiration   time.Time
 	}
 	tests := []struct {
 		name    string
@@ -135,6 +136,7 @@ func TestCreateMultisigTx(t *testing.T) {
 				signature:    "4d974561be4675853e0bc6062eac412228e94b16c6ba86dcfedccc1ef2b2a5156ab5aaddbd11f9d88786563fe9f3c17ca5e44a9936621b027b3179284dd86dc000",
 				outputOwners: "OutputOwners",
 				metadata:     "metadata",
+				expiration:   time.Now().Add(time.Hour * 24 * 7),
 				owners:       []string{"P-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3", "P-kopernikus18jma8ppw3nhx5r4ap8clazz0dps7rv5uuvjh68"},
 			},
 			want:    "bc6246f58b5aba675f4071bd1a13d7a774384e42f301208d1c2b0f22ee602e69",
@@ -165,7 +167,7 @@ func TestCreateMultisigTx(t *testing.T) {
 			d := &multisigTxDao{
 				db: tt.fields.db,
 			}
-			got, err := d.CreateMultisigTx(tt.args.id, tt.args.alias, tt.args.threshold, tt.args.unsignedTx, tt.args.creator, tt.args.signature, tt.args.outputOwners, tt.args.metadata, tt.args.owners)
+			got, err := d.CreateMultisigTx(tt.args.id, tt.args.alias, tt.args.threshold, tt.args.unsignedTx, tt.args.creator, tt.args.signature, tt.args.outputOwners, tt.args.metadata, tt.args.owners, &tt.args.expiration)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CreateMultisigTx() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/db/migrations/001_multisig_schema.up.sql
+++ b/db/migrations/001_multisig_schema.up.sql
@@ -7,6 +7,7 @@ CREATE TABLE multisig_tx
     transaction_id  VARCHAR(56)     NULL,
     output_owners   VARCHAR(255)    NOT NULL,
     metadata        VARCHAR(255)    NOT NULL,
+    expires_at      DATETIME        NULL,
     created_at      DATETIME        NOT NULL,
     PRIMARY KEY (id)
 );

--- a/dto/multisig_tx_args.go
+++ b/dto/multisig_tx_args.go
@@ -11,6 +11,7 @@ type MultisigTxArgs struct {
 	Signature    string `json:"signature" binding:"required"`
 	OutputOwners string `json:"outputOwners" binding:"required"`
 	Metadata     string `json:"metadata"`
+	Expiration   int64  `json:"expiration"`
 }
 
 type SignTxArgs struct {

--- a/handler/multisig_handler_test.go
+++ b/handler/multisig_handler_test.go
@@ -128,6 +128,7 @@ func TestGetAllMultisigTxForAlias(t *testing.T) {
 	mockMultisigService := service.NewMockMultisigService(ctrl)
 	h := NewMultisigHandler(mockMultisigService)
 
+	now := time.Now()
 	mock := model.MultisigTx{
 		Id:           "1",
 		Alias:        "P-kopernikus1k4przmfu79ypp4u7y98glmdpzwk0u3sc7saazy",
@@ -142,7 +143,7 @@ func TestGetAllMultisigTxForAlias(t *testing.T) {
 				Signature:    "4d974561be4675853e0bc6062eac412228e94b16c6ba86dcfedccc1ef2b2a5156ab5aaddbd11f9d88786563fe9f3c17ca5e44a9936621b027b3179284dd86dc000",
 			},
 		},
-		Timestamp: time.Now(),
+		Timestamp: &now,
 	}
 	mockResult := make([]model.MultisigTx, 0)
 	mockResult = append(mockResult, mock)
@@ -292,6 +293,7 @@ func TestSignMultisigTx(t *testing.T) {
 	mockMultisigService := service.NewMockMultisigService(ctrl)
 	h := NewMultisigHandler(mockMultisigService)
 
+	now := time.Now().UTC()
 	mockResult := &model.MultisigTx{
 		Id:           "1",
 		UnsignedTx:   "000000002004000003ea010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
@@ -306,7 +308,7 @@ func TestSignMultisigTx(t *testing.T) {
 				Signature:    "4d974561be4675853e0bc6062eac412228e94b16c6ba86dcfedccc1ef2b2a5156ab5aaddbd11f9d88786563fe9f3c17ca5e44a9936621b027b3179284dd86dc000",
 			},
 		},
-		Timestamp: time.Now().UTC(),
+		Timestamp: &now,
 	}
 	resultAsJson, _ := json.Marshal(mockResult)
 

--- a/model/multisig_tx.go
+++ b/model/multisig_tx.go
@@ -5,7 +5,9 @@
 
 package model
 
-import "time"
+import (
+	"time"
+)
 
 type MultisigTx struct {
 	Id            string            `json:"id" binding:"required"`
@@ -15,8 +17,9 @@ type MultisigTx struct {
 	TransactionId string            `json:"transactionId"`
 	OutputOwners  string            `json:"outputOwners" binding:"required"`
 	Metadata      string            `json:"metadata"`
+	Expiration    *time.Time        `json:"expiration,omitempty"`
 	Owners        []MultisigTxOwner `json:"owners" binding:"required"`
-	Timestamp     time.Time         `json:"timestamp" binding:"required"`
+	Timestamp     *time.Time        `json:"timestamp" binding:"required"`
 }
 
 type MultisigTxOwner struct {

--- a/service/multisig_service_test.go
+++ b/service/multisig_service_test.go
@@ -6,10 +6,6 @@
 package service
 
 import (
-	"strconv"
-	"testing"
-	"time"
-
 	"github.com/chain4travel/camino-signavault/dao"
 	"github.com/chain4travel/camino-signavault/dto"
 	"github.com/chain4travel/camino-signavault/model"
@@ -19,6 +15,8 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
+	"strconv"
+	"testing"
 )
 
 const networkId = uint32(1002)
@@ -54,7 +52,6 @@ func TestCreateMultisigTx(t *testing.T) {
 		TransactionId: "",
 		OutputOwners:  "OutputOwners",
 		Metadata:      "",
-		Timestamp:     time.Now(),
 		Owners: []model.MultisigTxOwner{
 			{
 				MultisigTxId: id,
@@ -70,7 +67,7 @@ func TestCreateMultisigTx(t *testing.T) {
 	}
 
 	thresholdInt, _ := strconv.Atoi(mockAliasInfo.Result.Threshold)
-	mockDao.EXPECT().CreateMultisigTx(mockTx.Id, mockTx.Alias, thresholdInt, mockTx.UnsignedTx, mockTx.Owners[0].Address, mockTx.Owners[0].Signature, mockTx.OutputOwners, mockTx.Metadata, mockAliasInfo.Result.Addresses).Return(mockTx.Id, nil)
+	mockDao.EXPECT().CreateMultisigTx(mockTx.Id, mockTx.Alias, thresholdInt, mockTx.UnsignedTx, mockTx.Owners[0].Address, mockTx.Owners[0].Signature, mockTx.OutputOwners, mockTx.Metadata, mockAliasInfo.Result.Addresses, nil).Return(mockTx.Id, nil)
 	mockDao.EXPECT().GetMultisigTx(mockTx.Id, "", "").Return(&[]model.MultisigTx{mockTx}, nil).AnyTimes()
 	mockDao.EXPECT().PendingAliasExists("P-kopernikus1fq0jc8svlyazhygkj0s36qnl6s0km0h3uuc99e").Return(true, nil)
 	mockDao.EXPECT().PendingAliasExists(gomock.Any()).Return(false, nil).AnyTimes()
@@ -93,6 +90,7 @@ func TestCreateMultisigTx(t *testing.T) {
 					UnsignedTx:   mockTx.UnsignedTx,
 					Signature:    mockTx.Owners[0].Signature,
 					OutputOwners: mockTx.OutputOwners,
+					//Expiration:   mockTx.Expiration.Unix(),
 				},
 			},
 			err: nil,


### PR DESCRIPTION
## Description

This PR will add an expiration date on the transactions. This field is optional and if set SignaVault will filter out the transaction where this date has expired. If it is not set then this means that the transaction never expires.

The api is expecting the expiration field to be a unix epoch. e.g 1680704400

The expiration date is saved as UTC in the database.

## Changes
- An new filed "expires_at" of type datetime in the database (schema change)
- A new optional field in the multisig_tx_args struct "expiration" of type int64
- Changes in tests
- Changed in dao layer to accommodate the new field.