### PR TITLE
Chain id on npm package and example update

### DIFF
--- a/dto/multisig_tx_args.go
+++ b/dto/multisig_tx_args.go
@@ -25,5 +25,5 @@ type IssueTxArgs struct {
 }
 
 type IssueTxResponse struct {
-	TxID string `json:"txID"`
+	TxID string `json:"txID" binding:"required"`
 }

--- a/examples/addValidatorTx.ts
+++ b/examples/addValidatorTx.ts
@@ -144,7 +144,8 @@ const sendRegisterNodeTx = async (): Promise<any> => {
             signature: signatures[0][1],
             outputOwners: outputOwnersHex,
             // we send node's signature as metadata so it can be used form the issuer
-            metadata: signatures[2][1]
+            metadata: signatures[2][1],
+            chainId: PChainAlias
         })
     } catch (e) {
         console.log(e.response.data)
@@ -353,7 +354,8 @@ const sendAddValidatorTx = async (): Promise<any> => {
             outputOwners: outputOwnersHex,
             // we send node's signature as metadata so it can be used form the issuer
             metadata: signatures[2][1],
-            expiration: Math.floor(startDate)
+            expiration: Math.floor(startDate),
+            chainId: PChainAlias,
         })
     } catch (e) {
         console.log(e.response.data)

--- a/examples/package.json
+++ b/examples/package.json
@@ -21,7 +21,7 @@
     "typescript": "^5.0.2"
   },
   "dependencies": {
-    "@c4tplatform/signavaultjs": "^1.0.5",
+    "@c4tplatform/signavaultjs": "^1.0.7",
     "axios": "^1.3.4",
     "create-hash": "^1.2.0"
   }

--- a/signavaultjs/api.ts
+++ b/signavaultjs/api.ts
@@ -53,7 +53,7 @@ export interface DtoIssueTxResponse {
      * @type {string}
      * @memberof DtoIssueTxResponse
      */
-    'txID'?: string;
+    'txID': string;
 }
 /**
  * 
@@ -67,6 +67,12 @@ export interface DtoMultisigTxArgs {
      * @memberof DtoMultisigTxArgs
      */
     'alias': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof DtoMultisigTxArgs
+     */
+    'chainId': string;
     /**
      * 
      * @type {number}
@@ -142,6 +148,12 @@ export interface ModelMultisigTx {
      * @memberof ModelMultisigTx
      */
     'alias': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof ModelMultisigTx
+     */
+    'chainId': string;
     /**
      * 
      * @type {string}

--- a/signavaultjs/package.json
+++ b/signavaultjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@c4tplatform/signavaultjs",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "description": "",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",


### PR DESCRIPTION
This PR adds the chainID field on npm module and updates the addValidatorTx example.