### PR TITLE
CancelMultisigTx implementation

### DIFF
--- a/cmd/camino-signavault/main.go
+++ b/cmd/camino-signavault/main.go
@@ -50,7 +50,7 @@ func startRouter(cfg *util.Config) {
 
 	api.POST("/multisig", h.CreateMultisigTx)
 	api.POST("/multisig/issue", h.IssueMultisigTx)
-	api.POST("/multisig/cancel/:id", h.CancelMultisigTx)
+	api.POST("/multisig/cancel", h.CancelMultisigTx)
 	api.PUT("/multisig/:id", h.SignMultisigTx)
 	api.GET("/multisig/:alias", h.GetAllMultisigTxForAlias)
 

--- a/cmd/camino-signavault/main.go
+++ b/cmd/camino-signavault/main.go
@@ -6,10 +6,11 @@
 package main
 
 import (
+	"log"
+
 	"github.com/chain4travel/camino-signavault/dao"
 	"github.com/chain4travel/camino-signavault/db"
 	"github.com/chain4travel/camino-signavault/service"
-	"log"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
@@ -49,6 +50,7 @@ func startRouter(cfg *util.Config) {
 
 	api.POST("/multisig", h.CreateMultisigTx)
 	api.POST("/multisig/issue", h.IssueMultisigTx)
+	api.POST("/multisig/cancel/:id", h.CancelMultisigTx)
 	api.PUT("/multisig/:id", h.SignMultisigTx)
 	api.GET("/multisig/:alias", h.GetAllMultisigTxForAlias)
 

--- a/dao/mock_multisig_tx_dao.go
+++ b/dao/mock_multisig_tx_dao.go
@@ -6,6 +6,7 @@ package dao
 
 import (
 	reflect "reflect"
+	time "time"
 
 	model "github.com/chain4travel/camino-signavault/model"
 	gomock "github.com/golang/mock/gomock"
@@ -92,6 +93,21 @@ func (m *MockMultisigTxDao) PendingAliasExists(arg0, arg1 string) (bool, error) 
 func (mr *MockMultisigTxDaoMockRecorder) PendingAliasExists(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PendingAliasExists", reflect.TypeOf((*MockMultisigTxDao)(nil).PendingAliasExists), arg0, arg1)
+}
+
+// UpdateExpirationDate mocks base method.
+func (m *MockMultisigTxDao) UpdateExpirationDate(arg0 string, arg1 time.Time) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateExpirationDate", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateExpirationDate indicates an expected call of UpdateExpirationDate.
+func (mr *MockMultisigTxDaoMockRecorder) UpdateExpirationDate(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateExpirationDate", reflect.TypeOf((*MockMultisigTxDao)(nil).UpdateExpirationDate), arg0, arg1)
 }
 
 // UpdateTransactionId mocks base method.

--- a/dto/multisig_tx_args.go
+++ b/dto/multisig_tx_args.go
@@ -30,6 +30,7 @@ type IssueTxResponse struct {
 }
 
 type CancelTxArgs struct {
+	Id        string `json:"id" binding:"required"`
 	Timestamp string `json:"timestamp" binding:"required"`
 	Signature string `json:"signature" binding:"required"`
 }

--- a/dto/multisig_tx_args.go
+++ b/dto/multisig_tx_args.go
@@ -28,3 +28,8 @@ type IssueTxArgs struct {
 type IssueTxResponse struct {
 	TxID string `json:"txID" binding:"required"`
 }
+
+type CancelTxArgs struct {
+	Timestamp string `json:"timestamp" binding:"required"`
+	Signature string `json:"signature" binding:"required"`
+}

--- a/examples/package.json
+++ b/examples/package.json
@@ -21,7 +21,7 @@
     "typescript": "^5.0.2"
   },
   "dependencies": {
-    "@c4tplatform/signavaultjs": "^1.0.9",
+    "@c4tplatform/signavaultjs": "^1.0.10",
     "axios": "^1.3.4",
     "create-hash": "^1.2.0"
   }

--- a/examples/package.json
+++ b/examples/package.json
@@ -21,7 +21,7 @@
     "typescript": "^5.0.2"
   },
   "dependencies": {
-    "@c4tplatform/signavaultjs": "^1.0.7",
+    "@c4tplatform/signavaultjs": "^1.0.9",
     "axios": "^1.3.4",
     "create-hash": "^1.2.0"
   }

--- a/handler/multisig_handler.go
+++ b/handler/multisig_handler.go
@@ -188,10 +188,8 @@ func (h *multisigHandler) IssueMultisigTx(ctx *gin.Context) {
 // @Success 204
 // @Failure 400 {object} dto.SignavaultError
 // @ID CancelMultisigTx
-// @Router /multisig/cancel/{id} [post]
+// @Router /multisig/cancel [post]
 func (h *multisigHandler) CancelMultisigTx(ctx *gin.Context) {
-	id := ctx.Param("id")
-
 	var cancelTxArgs *dto.CancelTxArgs
 	err := ctx.BindJSON(&cancelTxArgs)
 	if err != nil {
@@ -203,7 +201,7 @@ func (h *multisigHandler) CancelMultisigTx(ctx *gin.Context) {
 		return
 	}
 
-	err = h.multisigService.CancelMultisigTx(id, cancelTxArgs)
+	err = h.multisigService.CancelMultisigTx(cancelTxArgs)
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest,
 			&dto.SignavaultError{

--- a/service/mock_multisig_service.go
+++ b/service/mock_multisig_service.go
@@ -37,17 +37,17 @@ func (m *MockMultisigService) EXPECT() *MockMultisigServiceMockRecorder {
 }
 
 // CancelMultisigTx mocks base method.
-func (m *MockMultisigService) CancelMultisigTx(arg0 string, arg1 *dto.CancelTxArgs) error {
+func (m *MockMultisigService) CancelMultisigTx(arg0 *dto.CancelTxArgs) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CancelMultisigTx", arg0, arg1)
+	ret := m.ctrl.Call(m, "CancelMultisigTx", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CancelMultisigTx indicates an expected call of CancelMultisigTx.
-func (mr *MockMultisigServiceMockRecorder) CancelMultisigTx(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMultisigServiceMockRecorder) CancelMultisigTx(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelMultisigTx", reflect.TypeOf((*MockMultisigService)(nil).CancelMultisigTx), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelMultisigTx", reflect.TypeOf((*MockMultisigService)(nil).CancelMultisigTx), arg0)
 }
 
 // CreateMultisigTx mocks base method.

--- a/service/mock_multisig_service.go
+++ b/service/mock_multisig_service.go
@@ -36,6 +36,20 @@ func (m *MockMultisigService) EXPECT() *MockMultisigServiceMockRecorder {
 	return m.recorder
 }
 
+// CancelMultisigTx mocks base method.
+func (m *MockMultisigService) CancelMultisigTx(arg0 string, arg1 *dto.CancelTxArgs) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CancelMultisigTx", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CancelMultisigTx indicates an expected call of CancelMultisigTx.
+func (mr *MockMultisigServiceMockRecorder) CancelMultisigTx(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelMultisigTx", reflect.TypeOf((*MockMultisigService)(nil).CancelMultisigTx), arg0, arg1)
+}
+
 // CreateMultisigTx mocks base method.
 func (m *MockMultisigService) CreateMultisigTx(arg0 *dto.MultisigTxArgs) (*model.MultisigTx, error) {
 	m.ctrl.T.Helper()

--- a/service/multisig_service.go
+++ b/service/multisig_service.go
@@ -55,7 +55,7 @@ type MultisigService interface {
 	GetMultisigTx(id string) (*model.MultisigTx, error)
 	SignMultisigTx(id string, signer *dto.SignTxArgs) (*model.MultisigTx, error)
 	IssueMultisigTx(issueTxArgs *dto.IssueTxArgs) (ids.ID, error)
-	CancelMultisigTx(id string, cancelTxArgs *dto.CancelTxArgs) error
+	CancelMultisigTx(cancelTxArgs *dto.CancelTxArgs) error
 }
 
 type multisigService struct {
@@ -277,13 +277,13 @@ func (s *multisigService) IssueMultisigTx(sendTxArgs *dto.IssueTxArgs) (ids.ID, 
 	return txID, nil
 }
 
-func (s *multisigService) CancelMultisigTx(id string, cancelTxArgs *dto.CancelTxArgs) error {
+func (s *multisigService) CancelMultisigTx(cancelTxArgs *dto.CancelTxArgs) error {
 	owner, err := s.getAddressFromSignature(cancelTxArgs.Timestamp, cancelTxArgs.Signature, false)
 	if err != nil {
 		return ErrParsingSignature
 	}
 
-	multisigTx, err := s.GetMultisigTx(id)
+	multisigTx, err := s.GetMultisigTx(cancelTxArgs.Id)
 	if err != nil {
 		return err
 	}
@@ -293,7 +293,7 @@ func (s *multisigService) CancelMultisigTx(id string, cancelTxArgs *dto.CancelTx
 		return ErrAddressNotOwner
 	}
 
-	_, err = s.dao.UpdateExpirationDate(id, time.Now().UTC())
+	_, err = s.dao.UpdateExpirationDate(cancelTxArgs.Id, time.Now().UTC())
 	if err != nil {
 		return err
 	}

--- a/service/node_service.go
+++ b/service/node_service.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 
 	"github.com/ava-labs/avalanchego/ids"
-
 	"github.com/ava-labs/avalanchego/vms/platformvm"
 
 	"github.com/chain4travel/camino-signavault/model"

--- a/signavaultjs/api.ts
+++ b/signavaultjs/api.ts
@@ -34,6 +34,12 @@ export interface DtoCancelTxArgs {
      * @type {string}
      * @memberof DtoCancelTxArgs
      */
+    'id': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof DtoCancelTxArgs
+     */
     'signature': string;
     /**
      * 
@@ -279,7 +285,7 @@ export const MultisigApiAxiosParamCreator = function (configuration?: Configurat
             assertParamExists('cancelMultisigTx', 'id', id)
             // verify required parameter 'cancelTxArgs' is not null or undefined
             assertParamExists('cancelMultisigTx', 'cancelTxArgs', cancelTxArgs)
-            const localVarPath = `/multisig/cancel/{id}`
+            const localVarPath = `/multisig/cancel`
                 .replace(`{${"id"}}`, encodeURIComponent(String(id)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);

--- a/signavaultjs/api.ts
+++ b/signavaultjs/api.ts
@@ -26,6 +26,25 @@ import { BASE_PATH, COLLECTION_FORMATS, BaseAPI, RequiredError } from './base';
 /**
  * 
  * @export
+ * @interface DtoCancelTxArgs
+ */
+export interface DtoCancelTxArgs {
+    /**
+     * 
+     * @type {string}
+     * @memberof DtoCancelTxArgs
+     */
+    'signature': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof DtoCancelTxArgs
+     */
+    'timestamp': string;
+}
+/**
+ * 
+ * @export
  * @interface DtoIssueTxArgs
  */
 export interface DtoIssueTxArgs {
@@ -91,6 +110,12 @@ export interface DtoMultisigTxArgs {
      * @memberof DtoMultisigTxArgs
      */
     'outputOwners': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof DtoMultisigTxArgs
+     */
+    'parentTransaction'?: string;
     /**
      * 
      * @type {string}
@@ -186,6 +211,12 @@ export interface ModelMultisigTx {
     'owners': Array<ModelMultisigTxOwner>;
     /**
      * 
+     * @type {string}
+     * @memberof ModelMultisigTx
+     */
+    'parentTransaction'?: string;
+    /**
+     * 
      * @type {number}
      * @memberof ModelMultisigTx
      */
@@ -235,6 +266,46 @@ export interface ModelMultisigTxOwner {
  */
 export const MultisigApiAxiosParamCreator = function (configuration?: Configuration) {
     return {
+        /**
+         * 
+         * @summary Cancel a multisig transaction by setting the expiration to the current time
+         * @param {string} id Multisig transaction ID
+         * @param {DtoCancelTxArgs} cancelTxArgs CancelTxArgs object that contains the parameters for the multisig transaction to be canceled
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        cancelMultisigTx: async (id: string, cancelTxArgs: DtoCancelTxArgs, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'id' is not null or undefined
+            assertParamExists('cancelMultisigTx', 'id', id)
+            // verify required parameter 'cancelTxArgs' is not null or undefined
+            assertParamExists('cancelMultisigTx', 'cancelTxArgs', cancelTxArgs)
+            const localVarPath = `/multisig/cancel/{id}`
+                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(cancelTxArgs, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
         /**
          * 
          * @summary Create a new multisig transaction
@@ -407,6 +478,18 @@ export const MultisigApiFp = function(configuration?: Configuration) {
     return {
         /**
          * 
+         * @summary Cancel a multisig transaction by setting the expiration to the current time
+         * @param {string} id Multisig transaction ID
+         * @param {DtoCancelTxArgs} cancelTxArgs CancelTxArgs object that contains the parameters for the multisig transaction to be canceled
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async cancelMultisigTx(id: string, cancelTxArgs: DtoCancelTxArgs, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.cancelMultisigTx(id, cancelTxArgs, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * 
          * @summary Create a new multisig transaction
          * @param {DtoMultisigTxArgs} multisigTxArgs The input parameters for the multisig transaction
          * @param {*} [options] Override http request option.
@@ -464,6 +547,17 @@ export const MultisigApiFactory = function (configuration?: Configuration, baseP
     return {
         /**
          * 
+         * @summary Cancel a multisig transaction by setting the expiration to the current time
+         * @param {string} id Multisig transaction ID
+         * @param {DtoCancelTxArgs} cancelTxArgs CancelTxArgs object that contains the parameters for the multisig transaction to be canceled
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        cancelMultisigTx(id: string, cancelTxArgs: DtoCancelTxArgs, options?: any): AxiosPromise<void> {
+            return localVarFp.cancelMultisigTx(id, cancelTxArgs, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
          * @summary Create a new multisig transaction
          * @param {DtoMultisigTxArgs} multisigTxArgs The input parameters for the multisig transaction
          * @param {*} [options] Override http request option.
@@ -515,6 +609,19 @@ export const MultisigApiFactory = function (configuration?: Configuration, baseP
  * @extends {BaseAPI}
  */
 export class MultisigApi extends BaseAPI {
+    /**
+     * 
+     * @summary Cancel a multisig transaction by setting the expiration to the current time
+     * @param {string} id Multisig transaction ID
+     * @param {DtoCancelTxArgs} cancelTxArgs CancelTxArgs object that contains the parameters for the multisig transaction to be canceled
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof MultisigApi
+     */
+    public cancelMultisigTx(id: string, cancelTxArgs: DtoCancelTxArgs, options?: AxiosRequestConfig) {
+        return MultisigApiFp(this.configuration).cancelMultisigTx(id, cancelTxArgs, options).then((request) => request(this.axios, this.basePath));
+    }
+
     /**
      * 
      * @summary Create a new multisig transaction

--- a/signavaultjs/package.json
+++ b/signavaultjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@c4tplatform/signavaultjs",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",

--- a/signavaultjs/package.json
+++ b/signavaultjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@c4tplatform/signavaultjs",
-  "version": "1.0.7",
+  "version": "1.0.9",
   "description": "",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",


### PR DESCRIPTION
This PR adds the implementation of cancel multisig transaction and also updates the example of registerNodeTx and the npm module accordingly. 

When the client sends a request to cancel an already existing multisig transaction, signavault sets the expiration date to current timestamp so that the transaction will be instantly expired.