### PR TITLE
Delete pending tx on cancel

### DIFF
--- a/dao/mock_multisig_tx_dao.go
+++ b/dao/mock_multisig_tx_dao.go
@@ -65,6 +65,21 @@ func (mr *MockMultisigTxDaoMockRecorder) CreateMultisigTx(arg0 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMultisigTx", reflect.TypeOf((*MockMultisigTxDao)(nil).CreateMultisigTx), arg0)
 }
 
+// DeletePendingTx mocks base method.
+func (m *MockMultisigTxDao) DeletePendingTx(arg0 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeletePendingTx", arg0)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeletePendingTx indicates an expected call of DeletePendingTx.
+func (mr *MockMultisigTxDaoMockRecorder) DeletePendingTx(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePendingTx", reflect.TypeOf((*MockMultisigTxDao)(nil).DeletePendingTx), arg0)
+}
+
 // GetMultisigTx mocks base method.
 func (m *MockMultisigTxDao) GetMultisigTx(arg0, arg1, arg2 string) (*[]model.MultisigTx, error) {
 	m.ctrl.T.Helper()

--- a/handler/multisig_handler.go
+++ b/handler/multisig_handler.go
@@ -183,7 +183,6 @@ func (h *multisigHandler) IssueMultisigTx(ctx *gin.Context) {
 // @Tags Multisig
 // @Accept json
 // @Produce json
-// @Param id path string true "Multisig transaction ID"
 // @Param cancelTxArgs body dto.CancelTxArgs true "CancelTxArgs object that contains the parameters for the multisig transaction to be canceled"
 // @Success 204
 // @Failure 400 {object} dto.SignavaultError

--- a/service/multisig_service.go
+++ b/service/multisig_service.go
@@ -295,7 +295,7 @@ func (s *multisigService) CancelMultisigTx(cancelTxArgs *dto.CancelTxArgs) error
 		return ErrAddressNotOwner
 	}
 
-	_, err = s.dao.UpdateExpirationDate(cancelTxArgs.Id, time.Now().UTC())
+	_, err = s.dao.DeletePendingTx(cancelTxArgs.Id)
 	if err != nil {
 		return err
 	}

--- a/service/multisig_service_test.go
+++ b/service/multisig_service_test.go
@@ -512,7 +512,7 @@ func TestCancelMultisigTx(t *testing.T) {
 
 	// mock without signer
 	mockDao.EXPECT().GetMultisigTx(mockTx.Id, "", "").Return(&[]model.MultisigTx{mockTx}, nil).AnyTimes()
-	mockDao.EXPECT().UpdateExpirationDate(mockTx.Id, gomock.Any()).Return(true, nil).AnyTimes()
+	mockDao.EXPECT().DeletePendingTx(mockTx.Id).Return(true, nil).AnyTimes()
 
 	type args struct {
 		cancelArgs *dto.CancelTxArgs


### PR DESCRIPTION
## Description
On performing a cancel tx operation, the tx will be deleted from signavault as long as it is still pending. 

Previous functionality would set the tx to expire and keep it in the database but this did not allow us to recreate the exact same tx due to primary key violation.