### PR TITLE
[DB] Increase VARCHAR size of columns unsigned_tx, output_owners and switch charset to ascii

### DIFF
--- a/db/migrations/004_increase_unsigned_tx_output_owners_size.down.sql
+++ b/db/migrations/004_increase_unsigned_tx_output_owners_size.down.sql
@@ -1,2 +1,2 @@
-ALTER TABLE multisig_tx MODIFY unsigned_tx VARCHAR(4096);
-ALTER TABLE multisig_tx MODIFY output_owners VARCHAR(512);
+ALTER TABLE multisig_tx MODIFY unsigned_tx VARCHAR(4096) CHARACTER SET utf8mb4;
+ALTER TABLE multisig_tx MODIFY output_owners VARCHAR(512) CHARACTER SET utf8mb4;

--- a/db/migrations/004_increase_unsigned_tx_output_owners_size.up.sql
+++ b/db/migrations/004_increase_unsigned_tx_output_owners_size.up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE multisig_tx MODIFY unsigned_tx VARCHAR(65535);
-ALTER TABLE multisig_tx MODIFY output_owners VARCHAR(65535);
+ALTER TABLE multisig_tx MODIFY unsigned_tx VARCHAR(32768) CHARACTER SET ascii;
+ALTER TABLE multisig_tx MODIFY output_owners VARCHAR(16384) CHARACTER SET ascii;


### PR DESCRIPTION
## Why this should be merged
This PR addresses the issue of storing values in varchar columns `unsigned_tx` and `output_owners` of `multisig_tx` that exceed the currently low set limits. 

## How this works
It increases VARCHAR size of columns `unsigned_tx`, `output_owners` to 32768 and respectively 16384 and changes default charset from utf8mb4 to ascii.

Notes:
- This fix serves as a temporary solution. In the long-term a redesign/documentation of db decisions is necessary. 

## How this was tested
Manual and unit tests
N/A